### PR TITLE
Ship, Shield, Starfield and Projectiles now draw

### DIFF
--- a/Engine/Graphics.cpp
+++ b/Engine/Graphics.cpp
@@ -333,21 +333,41 @@ void Graphics::DrawRect( int X, int Y, int Width, int Height, Color C )
 	}
 }
 
+void Graphics::DrawRectOutline( int X, int Y, int Width, int Height, Color C )
+{
+	const int left = X;
+	const int top = Y;
+	const int right = X + Width;
+	const int bottom = Y + Height;
+
+	// Draw top
+	DrawLine( left,  top,	 right, top,	C );
+	// Draw bottom
+	DrawLine( left,  bottom, right, bottom, C );
+	// Draw left
+	DrawLine( left,  top,	 left,  bottom, C );
+	// Draw right
+	DrawLine( right, top,	 right, bottom, C );
+}
+
 void Graphics::DrawCircle( int Cx, int Cy, int Radius, Color C )
 {
 	int radius_squared = Radius * Radius;
 	int x_pivot = ( int )( Radius * 0.70710678118f + 0.5f );
+
+	auto DrawQuadrant = [ this, Cx, Cy, C ]( int X, int Y )
+	{
+		PutPixel( Cx + X, Cy + Y, C );
+		PutPixel( Cx - X, Cy + Y, C );
+		PutPixel( Cx + X, Cy - Y, C );
+		PutPixel( Cx - X, Cy - Y, C );
+	};
+
 	for( int x = 0; x <= x_pivot; x++ )
 	{
 		int y = ( int )( sqrtf( ( radius_squared - ( x*x ) ) ) + 0.5f );
-		PutPixel( Cx + x, Cy + y, C );
-		PutPixel( Cx - x, Cy + y, C );
-		PutPixel( Cx + x, Cy - y, C );
-		PutPixel( Cx - x, Cy - y, C );
-		PutPixel( Cx + y, Cy + x, C );
-		PutPixel( Cx - y, Cy + x, C );
-		PutPixel( Cx + y, Cy - x, C );
-		PutPixel( Cx - y, Cy - x, C );
+		DrawQuadrant( x, y );
+		DrawQuadrant( y, x );
 	}
 }
 
@@ -356,7 +376,7 @@ void Graphics::DrawLine( int x1, int y1, int x2, int y2, Color c )
 	const int dx = x2 - x1;
 	const int dy = y2 - y1;
 
-	if( dy == 0 && dx == 0 )
+	if( ( dy == 0 && dx == 0 ) && ( x1 > 0 && x2 < ScreenWidth ) && (y1 > 0 && y2 < ScreenHeight ) )
 	{
 		PutPixel( x1, y1, c );
 	}
@@ -364,18 +384,18 @@ void Graphics::DrawLine( int x1, int y1, int x2, int y2, Color c )
 	{
 		if( dy < 0 )
 		{
-			int temp = x1;
-			x1 = x2;
-			x2 = temp;
-			temp = y1;
-			y1 = y2;
-			y2 = temp;
+			std::swap( x1, x2 );
+			std::swap( y1, y2 );
 		}
 		const float m = ( float )dx / ( float )dy;
 		const float b = x1 - m*y1;
-		for( int y = y1; y <= y2; y = y + 1 )
+
+		const int y_start = std::max( 0, y1 );
+		const int y_end = std::min( ScreenHeight - 1, y2 );
+		for( int y = y_start; y <= y_end; ++y)
 		{
-			int x = ( int )( m*y + b + 0.5f );
+			const int x = ( int )( ( m * y ) + b + 0.5f );
+			if( x >= ScreenWidth|| x < 0 ) return;			
 			PutPixel( x, y, c );
 		}
 	}
@@ -383,18 +403,18 @@ void Graphics::DrawLine( int x1, int y1, int x2, int y2, Color c )
 	{
 		if( dx < 0 )
 		{
-			int temp = x1;
-			x1 = x2;
-			x2 = temp;
-			temp = y1;
-			y1 = y2;
-			y2 = temp;
+			std::swap( x1, x2 );
+			std::swap( y1, y2 );
 		}
 		const float m = ( float )dy / ( float )dx;
 		const float b = y1 - m*x1;
-		for( int x = x1; x <= x2; x = x + 1 )
+
+		const int x_start = std::max( 0, x1 );
+		const int x_end = std::min( ScreenWidth - 1, x2 );
+		for( int x = x_start; x <= x_end; ++x )
 		{
-			int y = ( int )( m*x + b + 0.5f );
+			const int y = ( int )( m*x + b + 0.5f );
+			if( y >= ScreenHeight || y < 0 ) return;
 			PutPixel( x, y, c );
 		}
 	}

--- a/Engine/Graphics.h
+++ b/Engine/Graphics.h
@@ -57,6 +57,7 @@ public:
 	}
 	void PutPixel( int x,int y,Color c );
 	void DrawRect( int X, int Y, int Width, int Height, Color C );
+	void DrawRectOutline( int X, int Y, int Width, int Height, Color C );
 	void DrawCircle( int Cx, int Cy, int Radius, Color C );
 	void DrawLine( int X0, int Y0, int X1, int Y1, Color C );
 	void DrawDisc( int Cx, int Cy, int Radius, Color C );

--- a/Engine/Player.cpp
+++ b/Engine/Player.cpp
@@ -10,24 +10,20 @@ Player::Player( Keyboard & Kbd, Mouse &Mse, Amalgum &rAmalgum )
 	keyboard( Kbd ),
 	mouse( Mse ),
 	amalgum( rAmalgum ),
-	ship( rAmalgum.ship )
+	ship( amalgum.ship )
 {}
 
 void Player::Update( float Dt )
 {
-	// Helpful vars for checking if ship is on/near edges
-	const SizeF screen = {
-		( float )Graphics::ScreenWidth,
-		( float )Graphics::ScreenHeight
-	};
+	// Helpful vars for checking if ship is on/near edges	
 	const SizeF ship_size = SizeF(
 		static_cast< float >( ship.width ),
 		static_cast< float >( ship.height )
 	);
-	const SizeF bounds = screen - ship_size - SizeF( 1.f, 1.f );
+	const SizeF bounds = Amalgum::screen_size - ship_size - SizeF( 1.f, 1.f );
 
 	
-	Vector ship_direction{};
+	Vector ship_direction{ 0.f, 0.f };
 
 	// Move clockwise
 	if( keyboard.KeyIsPressed( VK_LEFT ) || keyboard.KeyIsPressed( 'A' ) )
@@ -91,7 +87,7 @@ void Player::Update( float Dt )
 				const Vector ship_center = ship.position + ship_half_size;
 
 				// Add projectile to list in amalgum				
-				amalgum.projectile_list.emplace_back( Projectile( ship_center, ( Amalgum::screen_size - ship_center ).Normalize(), 3, 5, 300.f ) );
+				amalgum.projectile_list.emplace_back( Projectile( ship_center, ( ( Amalgum::screen_size * .5f ) - ship_center ).Normalize(), 3, 5, 300.f ) );
 			}
 		}
 	}
@@ -102,4 +98,5 @@ void Player::Update( float Dt )
 void Player::Draw( Graphics & Gfx )
 {
 	ship.Draw( Gfx );
+	amalgum.shield.Draw( ship.position, Gfx );
 }

--- a/Engine/Projectile.cpp
+++ b/Engine/Projectile.cpp
@@ -15,6 +15,6 @@ void Projectile::Update( float Dt )
 
 void Projectile::Draw( Graphics & Gfx )
 {
-	const Vector previous_position = position - velocity;
+	const Vector previous_position = position - (velocity.Normalize() * 10.f);
 	Gfx.DrawLine( previous_position.x, previous_position.y, position.x, position.y, Colors::Red );
 }

--- a/Engine/Shield.cpp
+++ b/Engine/Shield.cpp
@@ -35,10 +35,9 @@ void Shield::Draw( const Vector &ShipPosition, Graphics & Gfx )
 	const unsigned char value_green = static_cast<unsigned char>( 255.f * hp );
 	const unsigned char value_red = 255 - value_green;
 
-	Gfx.DrawCircle(
+	Gfx.DrawRectOutline(
 		static_cast< int >( ShipPosition.x ),
-		static_cast< int >( ShipPosition.x ),
-		static_cast< int >( radius ),
-		Color( value_red, value_green, 0 )
+		static_cast< int >( ShipPosition.y ),
+		32,32, Color( value_red, value_green, 0 )
 	);
 }

--- a/Engine/Ship.cpp
+++ b/Engine/Ship.cpp
@@ -1,4 +1,5 @@
 #include "Ship.h"
+#include "Amalgum.h"
 #include "Graphics.h"
 
 Ship::Ship( const Vector & Pos, const Vector & Heading, int Width, int Height, float Speed, float HP, float Damage )
@@ -8,12 +9,17 @@ Ship::Ship( const Vector & Pos, const Vector & Heading, int Width, int Height, f
 
 void Ship::Update( float Dt )
 {
-	position = position + velocity;
+	position = position + ( velocity * Dt);
 }
 
 void Ship::ClampToScreenEdges()
-{}
+{
+	position.x = min( Amalgum::screen_size.width - ( width + 1 ), max( position.x, 0.f ) );
+	position.y = min( Amalgum::screen_size.height - ( height + 1 ), max( position.y, 0.f ) );
+}
 
 void Ship::Draw( Graphics &Gfx )
-{}
+{
+	Gfx.DrawRect( position.x, position.y, width, height, Colors::Gray );
+}
 

--- a/Engine/Ship.h
+++ b/Engine/Ship.h
@@ -12,12 +12,4 @@ public:
 	void Draw( Graphics &Gfx ) override;
 	void ClampToScreenEdges();
 
-public:
-	
-	bool is_colliding,
-		 // Keyboard + mouse input
-	     is_left_pressed,
-	     is_right_pressed,
-	     is_space_pressed,
-	     is_Lmouse_pressed;
 };

--- a/Engine/StarField.cpp
+++ b/Engine/StarField.cpp
@@ -1,47 +1,41 @@
 #include "StarField.h"
+#include "Amalgum.h"
 #include "Graphics.h"
 #include "Random.h"
 
 StarField::StarField()
 	:
-	m_stars( m_star_count )
+	stars( star_count )
 {
-	for( auto &star : m_stars)
+
+	for( auto &star : stars )
 	{
-		const float x = Random::GetRandomFloat( 0.f, static_cast< float >( Graphics::ScreenWidth - 1 ) );
-		const float y = Random::GetRandomFloat( 0.f, static_cast< float >( Graphics::ScreenHeight - 1 ) );
-		star.m_pos = Vector( x, y );
-		star.m_speed = Random::GetRandomFloat( 0.f, 15.f );
+		const float x = Random::GetRandomFloat( 0.f, Amalgum::screen_size.width );
+		const float y = Random::GetRandomFloat( 0.f, Amalgum::screen_size.height );
+		star.pos = Vector( x, y );
+		star.speed = Random::GetRandomFloat( 0.f, 15.f );
 	}
 }
 
 void StarField::Update( float Dt )
-{
-	for( auto &star : m_stars )
+{	
+	for( auto &star : stars )
 	{
-		auto &pos = star.m_pos;
-		pos.y += ( star.m_speed * Dt );
-		
-		if( pos.y >= static_cast< float >( Graphics::ScreenHeight ) )
-		{	
-			pos.x = Random::GetRandomFloat( 0.f, static_cast< float >( Graphics::ScreenWidth - 1 ) );
-			pos.y = 0.f;
-			star.m_speed = Random::GetRandomFloat( 0.f, 15.f );
-			if( pos.x < 0.f || pos.x >= 800.f ||
-				pos.y < 0.f || pos.y >= 600.f )
-			{
-				int a = 0;
-			}
+		star.pos.y += ( star.speed * Dt );
+		if( star.pos.y >= Amalgum::screen_size.height )
+		{
+			star.pos.x = Random::GetRandomFloat( 0.f, Amalgum::screen_size.width );
+			star.pos.y = 0.f;
 		}
 	}
 }
 
 void StarField::Draw( Graphics & Gfx )const
 {
-	for( auto &star : m_stars )
+	for( auto &star : stars )
 	{
-		const int x = max( static_cast< int >( star.m_pos.x ) - 1, min( Graphics::ScreenWidth - 1, 0 ) );
-		const int y = max( static_cast< int >( star.m_pos.y ) - 1, min( Graphics::ScreenHeight - 1, 0 ) );
+		const int x = max( 0, min( Graphics::ScreenWidth - 1, static_cast< int >( star.pos.x ) ) );
+		const int y = max( 0, min( Graphics::ScreenHeight - 1, static_cast< int >( star.pos.y ) ) );
 		Gfx.PutPixel( x, y, Colors::White );
 	}
 }

--- a/Engine/StarField.h
+++ b/Engine/StarField.h
@@ -9,8 +9,8 @@ class StarField
 public:
 	struct Star
 	{
-		Vector m_pos = { 0.f, 0.f };
-		float m_speed = 0.f;
+		Vector pos = { 0.f, 0.f };
+		float speed = 0.f;
 	};
 	StarField();
 	~StarField() = default;
@@ -18,7 +18,7 @@ public:
 	void Update( float Dt );
 	void Draw( class Graphics &Gfx )const;
 private:
-	static constexpr unsigned m_star_count = 1250;
-	std::vector<Star> m_stars;
+	static constexpr unsigned star_count = 1250;
+	std::vector<Star> stars;
 };
 

--- a/Engine/Utilities.h
+++ b/Engine/Utilities.h
@@ -5,7 +5,7 @@
 
 inline Vector operator+( const SizeF &Size, const Vector &V )
 {
-	return Vector( V.x + Size.width, V.y + Size.height );
+	return Vector( Size.width + V.x, Size.height + V.y );
 }
 inline Vector operator+( const Vector &V, const SizeF &Size)
 {
@@ -14,7 +14,7 @@ inline Vector operator+( const Vector &V, const SizeF &Size)
 
 inline Vector operator-( const SizeF &Size, const Vector &V )
 {
-	return Vector( V.x - Size.width, V.y - Size.height );
+	return Vector( Size.width - V.x, Size.height - V.y );
 }
 inline Vector operator-( const Vector &V, const SizeF &Size )
 {

--- a/Engine/View.cpp
+++ b/Engine/View.cpp
@@ -8,21 +8,31 @@ View::View( Amalgum &Amal )
 
 void View::Render( Graphics & Gfx )
 {
+	// Draw background
 	amalgum.stars.Draw( Gfx );
-	amalgum.player.Draw( Gfx );
 
+	// Draw projectiles
 	for( auto &projectile : amalgum.projectile_list )
 	{
 		projectile.Draw( Gfx );
 	}
+
+	// Draw ship and shield
+	amalgum.player.Draw( Gfx );
+
+	// Draw motion tracking enemies
 	for( auto &enemy : amalgum.enemy_homing_list )
 	{
 		enemy.Draw( Gfx );
 	}
+
+	// Draw static tracking enemies
 	for( auto &enemy : amalgum.enemy_last_known_list )
 	{
 		enemy.Draw( Gfx );
 	}
+
+	// Draw kamakaze enemies
 	for( auto &enemy : amalgum.enemy_straight_list )
 	{
 		enemy.Draw( Gfx );


### PR DESCRIPTION
Use Amalgum::screen_size in Player::Update instead of creating new SizeF for bounds
Fix a bug where ship velocity and position were being set to random numbers after update, a vector wasn't being initialized
Fix the direction of projectile during launch
Add amalgum.shield.Draw to Player::Draw to draw the shield
Fix projectile drawing to be ajustable by Vector length
Change shield drawing from circle to square
Make ship move using delta time (Dt)
Finish Ship::ClampToScreenEdges
Finish Ship::Draw
Remove the move bools, Player controls handles input and controls ship
Fix and Cleanup code in Starfield
Remove m_ from member names in Starfield
Fix order of operations with operator- and operator+ with SizeF and Vector in Utilities.h
Finish adding the rest of the Entity::Draw calls