### PR TITLE
The compilation warnings are gone, commit

### DIFF
--- a/Engine/Amalgum.h
+++ b/Engine/Amalgum.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#ifndef FULL_WINTARD
 #define FULL_WINTARD
+#endif // !FULL_WINTAR
+
 #include <vector>
 #include "EnemyStraight.h"
 #include "EnemyTrackStatic.h"

--- a/Engine/ChiliWin.h
+++ b/Engine/ChiliWin.h
@@ -1,5 +1,5 @@
 /******************************************************************************************
-*	Chili DirectX Framework Version 16.07.20											  *
+*	Chili DirectX Framework Version 16.10.01											  *
 *	ChiliWin.h																			  *
 *	Copyright 2016 PlanetChili <http://www.planetchili.net>								  *
 *																						  *
@@ -21,11 +21,15 @@
 #pragma once
 
 // target Windows 7 or later
+#ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0601
 #include <sdkddkver.h>
+#endif
+
 // The following #defines disable a bunch of unused windows stuff. If you 
 // get weird errors when trying to do some windows stuff, try removing some
 // (or all) of these defines (it will increase build time though).
+#ifndef FULL_WINTARD
 #define WIN32_LEAN_AND_MEAN
 #define NOGDICAPMASKS
 #define NOSYSMETRICS
@@ -60,7 +64,12 @@
 #define NOPROXYSTUB
 #define NOIMAGE
 #define NOTAPE
+#endif
 
+#define NOMINMAX
+
+#ifndef STRICT
 #define STRICT
+#endif
 
 #include <Windows.h>

--- a/Engine/EnemyStraight.cpp
+++ b/Engine/EnemyStraight.cpp
@@ -1,3 +1,7 @@
+#ifndef FULL_WINTARD
+#define FULL_WINTARD
+#endif // !FULL_WINTARD
+
 #include "EnemyStraight.h"
 #include "Graphics.h"
 
@@ -12,9 +16,13 @@ EnemyStraight::EnemyStraight( const Vector & Pos, const Vector & Heading,
 void EnemyStraight::Update( float Dt )
 {
 	position = position + ( velocity * Dt );
+	
 }
 
 void EnemyStraight::Draw( Graphics & Gfx )
 {
-	Gfx.DrawRect( position.x, position.y, width, height, color );
+	Gfx.DrawRect( 
+		static_cast<int>( position.x ),
+		static_cast<int>( position.y ), 
+		width, height, color );
 }

--- a/Engine/EnemyTrackMotion.cpp
+++ b/Engine/EnemyTrackMotion.cpp
@@ -14,7 +14,10 @@ void EnemyTrackMotion::Update( float Dt )
 
 void EnemyTrackMotion::Draw( Graphics & Gfx )
 {
-	Gfx.DrawRect( position.x, position.y, width, height, color );
+	Gfx.DrawRect( 
+		static_cast<int>( position.x ),
+		static_cast<int>( position.y ),
+		width, height, color );
 }
 
 void EnemyTrackMotion::SetPlayerPosition( const Vector & PlayerPos )

--- a/Engine/EnemyTrackStatic.cpp
+++ b/Engine/EnemyTrackStatic.cpp
@@ -17,5 +17,8 @@ void EnemyTrackStatic::Update( float Dt)
 
 void EnemyTrackStatic::Draw( Graphics &Gfx )
 {
-	Gfx.DrawRect( position.x, position.y, width, height, color );
+	Gfx.DrawRect( 
+		static_cast<int>( position.x ),
+		static_cast<int>( position.y ),
+		width, height, color );
 }

--- a/Engine/Graphics.cpp
+++ b/Engine/Graphics.cpp
@@ -367,7 +367,7 @@ void Graphics::DrawCircle( int Cx, int Cy, int Radius, Color C )
 
 	for( int x = 0; x <= x_pivot; x++ )
 	{
-		int y = ( int )( sqrtf( ( radius_squared - ( x*x ) ) ) + 0.5f );
+		int y = static_cast<int>( sqrtf( static_cast<float>( radius_squared - ( x*x ) ) ) + 0.5f );
 		DrawQuadrant( x, y );
 		DrawQuadrant( y, x );
 	}

--- a/Engine/Graphics.h
+++ b/Engine/Graphics.h
@@ -19,6 +19,8 @@
 *	along with The Chili DirectX Framework.  If not, see <http://www.gnu.org/licenses/>.  *
 ******************************************************************************************/
 #pragma once
+
+#include "ChiliWin.h"
 #include <d3d11.h>
 #include <wrl.h>
 #include "ChiliException.h"

--- a/Engine/Level.h
+++ b/Engine/Level.h
@@ -12,7 +12,7 @@ public:
 
 private:
 	const unsigned int tier_goal = 10u;
-	int kill_count = 0;
+	unsigned int kill_count = 0u;
 	int difficulty_tier = 0;
 };
 

--- a/Engine/Player.h
+++ b/Engine/Player.h
@@ -1,6 +1,6 @@
 #pragma once
 
-class Amalgum;
+struct Amalgum;
 class Keyboard;
 class Mouse;
 class Ship;

--- a/Engine/Projectile.cpp
+++ b/Engine/Projectile.cpp
@@ -16,5 +16,10 @@ void Projectile::Update( float Dt )
 void Projectile::Draw( Graphics & Gfx )
 {
 	const Vector previous_position = position - (velocity.Normalize() * 10.f);
-	Gfx.DrawLine( previous_position.x, previous_position.y, position.x, position.y, Colors::Red );
+	Gfx.DrawLine( 
+		static_cast<int>(previous_position.x), 
+		static_cast<int>(previous_position.y), 
+		static_cast<int>(position.x), 
+		static_cast<int>(position.y), 
+		Colors::Red );
 }

--- a/Engine/Shield.h
+++ b/Engine/Shield.h
@@ -2,7 +2,7 @@
 
 #include "Vector.h"
 
-class Amalgum;
+struct Amalgum;
 class Graphics;
 
 class Shield

--- a/Engine/Ship.cpp
+++ b/Engine/Ship.cpp
@@ -14,12 +14,15 @@ void Ship::Update( float Dt )
 
 void Ship::ClampToScreenEdges()
 {
-	position.x = min( Amalgum::screen_size.width - ( width + 1 ), max( position.x, 0.f ) );
-	position.y = min( Amalgum::screen_size.height - ( height + 1 ), max( position.y, 0.f ) );
+	position.x = std::min( Amalgum::screen_size.width - ( width + 1 ),   std::max( position.x, 0.f ) );
+	position.y = std::min( Amalgum::screen_size.height - ( height + 1 ), std::max( position.y, 0.f ) );
 }
 
 void Ship::Draw( Graphics &Gfx )
 {
-	Gfx.DrawRect( position.x, position.y, width, height, Colors::Gray );
+	Gfx.DrawRect( 
+		static_cast<int>( position.x ),
+		static_cast<int>( position.y ),
+		width, height, Colors::Gray );
 }
 

--- a/Engine/Spawner.cpp
+++ b/Engine/Spawner.cpp
@@ -170,8 +170,8 @@ Spawner::EnemyConstructorParams Spawner::CreateBaseParams() const
 	
 	if( side == TOP || side == BOTTOM )
 	{
-		params.width = 70.f;
-		params.height = 30.f;
+		params.width = 70;
+		params.height = 30;
 		params.pos.x = Random::GetRandomFloat( 0.f, static_cast<float>( Graphics::ScreenWidth - params.width ) );
 		params.heading.x = 0.f;
 		if( side == TOP )

--- a/Engine/Spawner.h
+++ b/Engine/Spawner.h
@@ -11,7 +11,7 @@ class Spawner
 	{
 		Vector pos, heading;
 		float hp, speed, damage;
-		float width, height;
+		int width, height;
 		Color color;
 	};
 public:

--- a/Engine/StarField.cpp
+++ b/Engine/StarField.cpp
@@ -34,8 +34,8 @@ void StarField::Draw( Graphics & Gfx )const
 {
 	for( auto &star : stars )
 	{
-		const int x = max( 0, min( Graphics::ScreenWidth - 1, static_cast< int >( star.pos.x ) ) );
-		const int y = max( 0, min( Graphics::ScreenHeight - 1, static_cast< int >( star.pos.y ) ) );
+		const int x = std::max( 0, std::min( Graphics::ScreenWidth - 1, static_cast< int >( star.pos.x ) ) );
+		const int y = std::max( 0, std::min( Graphics::ScreenHeight - 1, static_cast< int >( star.pos.y ) ) );
 		Gfx.PutPixel( x, y, Colors::White );
 	}
 }

--- a/Engine/Text.cpp
+++ b/Engine/Text.cpp
@@ -1,3 +1,7 @@
+#ifndef FULL_WINTARD
+#define FULL_WINTARD
+#endif // !FULL_WINTAR
+
 #include "Text.h"
 #include "Graphics.h"
 #include <iomanip>

--- a/Engine/Vector.cpp
+++ b/Engine/Vector.cpp
@@ -27,7 +27,7 @@ Vector Vector::operator*( const float Rhs )const
 
 float Vector::GetMagnitude( ) const
 {
-	return sqrt( x * x + y * y );
+	return sqrtf( x * x + y * y );
 }
 
 Vector Vector::Normalize( ) const

--- a/Engine/View.cpp
+++ b/Engine/View.cpp
@@ -1,3 +1,7 @@
+#ifndef FULL_WINTARD
+#define FULL_WINTARD
+#endif // !FULL_WINTAR
+
 #include "View.h"
 #include "Amalgum.h"
 
@@ -39,12 +43,17 @@ void View::Render( Graphics & Gfx )
 	}
 
 	const TextFormat format( TextFormat::WhichFont::FIXEDSYS_SMALL, Colors::Green );
+
+	const int base_y = 100;
+	const int row_padding = 3;
 	// Display the current level
-	Gfx.DrawText( 0, 100, Text( amalgum.text_level ).Append( amalgum.level.GetDifficulty() ), format );
+	Gfx.DrawText( 0, base_y, Text( amalgum.text_level ).Append( amalgum.level.GetDifficulty() ), format );
 	
 	// Display the current shield percentage
-	Gfx.DrawText( 0, 130, Text( amalgum.text_shield ).Append( amalgum.shield.hp * 100.f ).Append( Text( "%" ) ), format );
+	const int second_row = base_y + format.font->char_height + row_padding;
+	Gfx.DrawText( 0, second_row, Text( amalgum.text_shield ).Append( amalgum.shield.hp * 100.f ).Append( Text( "%" ) ), format );
 
 	// Display the player's score
-	Gfx.DrawText( 0, 160, Text( amalgum.text_score ).Append(0), format );
+	const int third_row = second_row + format.font->char_height + row_padding;
+	Gfx.DrawText( 0, third_row, Text( amalgum.text_score ).Append(0), format );
 }

--- a/Engine/View.h
+++ b/Engine/View.h
@@ -2,7 +2,7 @@
 
 
 class Graphics;
-class Amalgum;
+struct  Amalgum;
 
 class View
 {

--- a/malagaMKII.txt
+++ b/malagaMKII.txt
@@ -25,9 +25,11 @@ Todo
 // Ammo upgrades
 Weaopn upgrades
 ----------
-1. Projectile properties
-	a. speed
-	b. damage
+{ // Redacted
+	1. Projectile properties
+		a. speed
+		b. damage
+}
 
 2. Weapon properties / tiers
 	a. single shot |
@@ -76,11 +78,13 @@ Game Screen
     To be decided
     ----------
     [can all be same points, just spawn timer different per color]
-    a. red bricks   -> shield
-    b. blue bricks  -> ammo
-    c. green bricks -> acceleration
-    d. pink bricks  -> ship speed
-    c. brown bricks -> bomb (destroy all enemies on screen) 
+    Priority    
+	-----------------------------------------------------------------
+		1	|	brown bricks -> bomb (destroy all enemies on screen)				
+		2	|	pink bricks  -> ship speed
+		3	|	blue bricks  -> weapon
+		4	|	red bricks   -> shield
+		5	|	green bricks -> acceleration
 
 3. health & shield bar
 
@@ -135,3 +139,20 @@ Game flow from a programming standpoint
 3e)	brown bricks -> bomb (destroy all enemies on screen) 
 
 4)	Enemy spawn mechanics
+
+
+Possible future additions
+-------------------------
+Limit perk drops (keep colored enemy count on screen low)
+5th Weapon upgrade chases perk enemies
+HUD
+Possible weapon upgrade: faster fire rate
+Add sounds 
+Add sprites
+Add network play
+
+
+
+
+
+


### PR DESCRIPTION
Updated ChiliWin.h with the version from his 3D_Fundamentals framework
Added preprocessor directive to avoid redefinition of the WinAPI macros
Cast floats to ints for draw calls to get rid of conversion warnings
Change min/max to std::min/std::max after updating ChiliWin.h, adding preprocessor directives and adding #include ChiliWin.h to Graphics.h